### PR TITLE
Handle missing podcast description

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ It is designed to run from the command line or via cron.
 Feed URLs and filter rules are stored in a YAML file. Each feed block
 contains the source URL and one or more output definitions. Each output has an
 optional list of keywords for inclusion or exclusion. An output may also
-override the resulting feed's `title` and `description` fields.
+override the resulting feed's `title` and `description` fields. Set
+`description: ""` to remove the description tag from the generated feed.
 When a feed defines `splits`, those act as additional outputs and can be mixed
 with a base output.
 

--- a/podfeedfilter/filterer.py
+++ b/podfeedfilter/filterer.py
@@ -107,8 +107,6 @@ def process_feed(cfg: FeedConfig):
             if desc is not None:
                 channel.remove(desc)
         rss_data = ET.tostring(root, encoding="utf-8", xml_declaration=True)
-        with open(output_path, "wb") as f:
-            f.write(rss_data)
-    else:
-        with open(output_path, "wb") as f:
-            f.write(rss_data)
+        
+    with open(output_path, "wb") as f:
+        f.write(rss_data)


### PR DESCRIPTION
## Summary
- set feed description from available metadata or fall back to the feed title
- allow removing the description from a feed by specifying `description: ""` in the config

## Testing
- `pip install -r requirements.txt`
- `python -m podfeedfilter -c feeds.yaml` *(fails: cannot download example feeds in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68744980f280832d81e0f2c237b83e0c

## Summary by Sourcery

Handle missing or empty feed descriptions by falling back to remote metadata fields or placeholder, and allow removal of description tag with `description: ""`

New Features:
- Allow removing the description element when `description` is set to an empty string in the config

Enhancements:
- Fall back to remote feed’s subtitle or summary when description is missing
- Use a default placeholder description if no metadata is available
- Strip out the `<description>` tag from the generated RSS when configured to remove it

Documentation:
- Document the `description: ""` option in README to remove the description tag