### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,6 +2,9 @@ name: Pylint
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/jkdelauney/podfeedfilter/security/code-scanning/1](https://github.com/jkdelauney/podfeedfilter/security/code-scanning/1)

To fix the issue, an explicit `permissions` block should be added to the workflow. Since the workflow only needs to read the repository contents (e.g., to check out code) and does not perform any write operations, the permissions can be restricted to `contents: read`. This can be set at the workflow level to apply to all jobs within the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
