### PR TITLE
Pylint permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -5,6 +5,22 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
+    # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idpermissions
+    permissions:
+      actions: read|write|none
+      attestations: read|write|none
+      checks: read|write|none
+      contents: read|write|none
+      deployments: read|write|none
+      id-token: write|none
+      issues: read|write|none
+      models: read|none
+      discussions: read|write|none
+      packages: read|write|none
+      pages: read|write|none
+      pull-requests: read|write|none
+      security-events: read|write|none
+  statuses: read|write|none
     strategy:
       matrix:
         python-version: ["3.10"]

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -20,7 +20,7 @@ jobs:
       pages: read|write|none
       pull-requests: read|write|none
       security-events: read|write|none
-  statuses: read|write|none
+      statuses: read|write|none
     strategy:
       matrix:
         python-version: ["3.10"]

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -42,5 +42,5 @@ jobs:
     - name: Upload Artifact
       uses: actions/upload-artifact@v4
       with:
-        name: lint.txt
-        path: lint.txt
+        name: lint_${{ matrix.python-version }}.txt
+        path: lint_${{ matrix.python-version }}.txt

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -37,8 +37,8 @@ jobs:
         pip install -r requirements-dev.txt
     - name: Analysing the code with pylint
       run: |
-        pylint $(git ls-files '*.py') --output=lint.txt || true
-        cat lint${{ matrix.python-version }}.txt
+        pylint $(git ls-files '*.py') --output=lint_${{ matrix.python-version }}.txt || true
+        cat lint_${{ matrix.python-version }}.txt
     - name: Upload Artifact
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Analysing the code with pylint
       run: |
         pylint $(git ls-files '*.py') --output=lint.txt || true
-        cat lint.txt
+        cat lint${{ matrix.python-version }}.txt
     - name: Upload Artifact
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -7,23 +7,23 @@ jobs:
     runs-on: ubuntu-latest
     # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idpermissions
     permissions:
-      actions: read|write|none
-      attestations: read|write|none
-      checks: read|write|none
-      contents: read|write|none
-      deployments: read|write|none
-      id-token: write|none
-      issues: read|write|none
-      models: read|none
-      discussions: read|write|none
-      packages: read|write|none
-      pages: read|write|none
-      pull-requests: read|write|none
-      security-events: read|write|none
-      statuses: read|write|none
+#     actions: read|write|none
+#     attestations: read|write|none
+#     checks: read|write|none
+      contents: read
+#     deployments: read|write|none
+#     discussions: read|write|none
+#     id-token: write|none
+#     issues: read|write|none
+#     models: read|none
+#     packages: read|write|none
+#     pages: read|write|none
+#     pull-requests: read|write|none
+#     security-events: read|write|none
+#     statuses: read|write|none
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.13.5"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Added permissions to pylint.yml to limit access to repo by the lint workflow.

## Summary by Sourcery

Tighten permissions on the pylint CI workflow, broaden Python version coverage, and improve lint artifact handling by versioning the output files.

Enhancements:
- Restrict GitHub Actions permissions in the pylint workflow to only read repository contents
- Extend the CI Python matrix to include versions 3.11, 3.12, 3.13, and 3.13.5
- Parameterize lint report filenames and artifact names by Python version