### PR TITLE
Fixes for PR19

### DIFF
--- a/podfeedfilter/filterer.py
+++ b/podfeedfilter/filterer.py
@@ -102,8 +102,9 @@ def _load_existing_entries(output_path: Path) -> tuple[list[feedparser.FeedParse
         parsed = feedparser.parse(output_path)
         for entry in parsed.entries:
             existing_entries.append(entry)
-            entry_id = str(entry.get('id') or entry.get('link'))
-            existing_ids.add(entry_id)
+            entry_id = entry.get('id') or entry.get('link')
+            if entry_id is not None:
+                existing_ids.add(str(entry_id))
 
     return existing_entries, existing_ids
 
@@ -137,7 +138,8 @@ def _filter_new_entries(remote_entries: list, existing_ids: set[str],
     new_entries = []
     for entry in remote_entries:
         entry_id = entry.get('id') or entry.get('link')
-        if entry_id in existing_ids:
+        # Skip entries without valid IDs or entries that already exist
+        if entry_id is None or str(entry_id) in existing_ids:
             continue
         if _entry_passes(entry, cfg.include, cfg.exclude):
             new_entries.append(entry)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,6 +141,51 @@ def create_test_yaml_config(config_dict: Dict[str, Any]) -> str:
     return yaml.dump(config_dict, default_flow_style=False)
 
 
+def create_mock_rss(title: str = "Test Podcast", description: str = "Test Description", 
+                   link: str = "http://example.com", episodes: list = None) -> str:
+    """Helper function to create a mock RSS feed XML string.
+    
+    Args:
+        title: The podcast title
+        description: The podcast description  
+        link: The podcast link
+        episodes: List of episode dicts with keys: title, description, link, guid
+        
+    Returns:
+        Complete RSS XML string
+    """
+    if episodes is None:
+        episodes = [{
+            'title': 'Test Episode',
+            'description': 'Test episode description',
+            'link': 'http://example.com/episode1',
+            'guid': 'episode1'
+        }]
+    
+    rss_template = """<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+<channel>
+<title>{title}</title>
+<description>{description}</description>
+<link>{link}</link>
+{items}
+</channel>
+</rss>"""
+    
+    items_xml = ""
+    for episode in episodes:
+        item_xml = f"""<item>
+<title>{episode.get('title', 'Test Episode')}</title>
+<description>{episode.get('description', 'Test description')}</description>
+<link>{episode.get('link', 'http://example.com/episode')}</link>
+<guid>{episode.get('guid', 'episode')}</guid>
+</item>
+"""
+        items_xml += item_xml
+    
+    return rss_template.format(title=title, description=description, link=link, items=items_xml)
+
+
 # Config fixture helpers
 CONFIG_DIR = TEST_DATA_DIR / "configs"
 

--- a/tests/test_config_load.py
+++ b/tests/test_config_load.py
@@ -192,7 +192,7 @@ feeds: []
         result = load_config(str(config_file))
 
         assert isinstance(result, list)
-        assert len(result) == 0
+        assert not result
 
     def test_missing_feeds_key(self, tmp_path):
         """Test handling missing feeds key."""
@@ -205,7 +205,7 @@ some_other_key: "value"
         result = load_config(str(config_file))
 
         assert isinstance(result, list)
-        assert len(result) == 0
+        assert not result
 
     def test_empty_config_file(self, tmp_path):
         """Test handling completely empty config file."""
@@ -216,7 +216,7 @@ some_other_key: "value"
         result = load_config(str(config_file))
 
         assert isinstance(result, list)
-        assert len(result) == 0
+        assert not result
 
     def test_missing_url_raises_key_error(self, tmp_path):
         """Test that missing url raises KeyError."""
@@ -304,7 +304,7 @@ feeds:
         result = load_config(str(config_file))
 
         # Should be empty because no output, include, exclude, title, or description
-        assert len(result) == 0
+        assert not result
 
     def test_base_output_created_with_any_optional_field(self, tmp_path):
         """Test that base output is created when any optional field is present."""

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -296,10 +296,6 @@ class TestPerformanceWithLongLists:
             # but filtered by include=['tech'] - only even episodes have "Tech Talk"
             tech_episodes = [e for e in output_feed.entries if 'tech' in e.get('title', '').lower()]
             assert len(tech_episodes) == 500  # Only even episodes have "Tech Talk"
-            
-            # Ensure Sports Content episodes are effectively omitted
-            sports_episodes = [e for e in output_feed.entries if 'sports content' in e.get('title', '').lower()]
-            assert len(sports_episodes) == 0  # Sports episodes should be excluded
 
         finally:
             # Restore original parse function

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -296,6 +296,10 @@ class TestPerformanceWithLongLists:
             # but filtered by include=['tech'] - only even episodes have "Tech Talk"
             tech_episodes = [e for e in output_feed.entries if 'tech' in e.get('title', '').lower()]
             assert len(tech_episodes) == 500  # Only even episodes have "Tech Talk"
+            
+            # Ensure Sports Content episodes are effectively omitted
+            sports_episodes = [e for e in output_feed.entries if 'sports content' in e.get('title', '').lower()]
+            assert len(sports_episodes) == 0  # Sports episodes should be excluded
 
         finally:
             # Restore original parse function

--- a/tests/test_feedparser_mock.py
+++ b/tests/test_feedparser_mock.py
@@ -52,7 +52,7 @@ def test_mock_feedparser_parse_empty_feed(mock_feedparser_parse, test_feed_urls)
 
     # Empty feed should still have feed metadata but no entries
     assert parsed_feed.feed.title is not None
-    assert len(parsed_feed.entries) == 0
+    assert not parsed_feed.entries
 
 
 def test_mock_feedparser_parse_nonexistent_mapping(mock_feedparser_parse):

--- a/tests/test_private_cli.py
+++ b/tests/test_private_cli.py
@@ -7,6 +7,7 @@ configuration file settings for all feeds.
 import subprocess
 import sys
 from pathlib import Path
+from .conftest import create_mock_rss
 
 
 class TestPrivateCLIFlag:
@@ -45,20 +46,7 @@ feeds:
         config_file.write_text(config_content)
 
         # Create mock RSS feed
-        mock_rss = """<?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0">
-<channel>
-<title>Test Podcast</title>
-<description>Test Description</description>
-<link>http://example.com</link>
-<item>
-<title>Test Episode</title>
-<description>Test episode description</description>
-<link>http://example.com/episode1</link>
-<guid>episode1</guid>
-</item>
-</channel>
-</rss>"""
+        mock_rss = create_mock_rss()
 
         # Create test data directory structure
         test_data_dir = tmp_path / "data" / "feeds"
@@ -136,20 +124,7 @@ feeds:
         config_file = tmp_path / "test_config.yaml"
         config_file.write_text(config_content)
 
-        mock_rss = """<?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0">
-<channel>
-<title>Test Podcast</title>
-<description>Test Description</description>
-<link>http://example.com</link>
-<item>
-<title>Test Episode</title>
-<description>Test episode description</description>
-<link>http://example.com/episode1</link>
-<guid>episode1</guid>
-</item>
-</channel>
-</rss>"""
+        mock_rss = create_mock_rss()
 
         # Create the data structure for testing
         test_data_dir = tmp_path / "data" / "feeds"


### PR DESCRIPTION
## Summary by Sourcery

Introduce a reusable RSS fixture, improve private flag testing, and harden entry filtering in feeder

New Features:
- Add test verifying that setting private: true in config marks feeds as private with default values intact

Enhancements:
- Add create_mock_rss helper to conftest and refactor tests to use it instead of inline XML
- Simplify empty-list assertions in config and feedparser tests by checking truthiness
- Enhance filterer logic to skip entries without valid IDs and normalize ID extraction before filtering